### PR TITLE
S93.24 Reverse put and post for ClientSettings

### DIFF
--- a/src/Connector/Client/ClientSettingsConnector.php
+++ b/src/Connector/Client/ClientSettingsConnector.php
@@ -42,14 +42,14 @@ class ClientSettingsConnector extends BaseApiResourceConnector
      * @return bool
      */
     public function canUpdate() {
-        return true;
+        return false;
     }
 
     /**
      * @return bool
      */
     public function canCreate() {
-        return false;
+        return true;
     }
 
     /**
@@ -65,6 +65,13 @@ class ClientSettingsConnector extends BaseApiResourceConnector
      */
     public function resourceExists()
     {
-        return !empty($this->getId());
+        // Always use POST
+        return false;
+    }
+
+
+    public function getDataForPost()
+    {
+        return parent::getDataForUpdate();
     }
 }

--- a/tests/Connector/ClientSettingsConnectorTest.php
+++ b/tests/Connector/ClientSettingsConnectorTest.php
@@ -30,4 +30,28 @@ class ClientSettingsConnectorTest extends \PHPUnit_Framework_TestCase
         $connector->setResource($resource);
         $connector->getEndpoint();
     }
+
+
+    public function testIfCanCreate()
+    {
+        $connector = new ClientSettingsConnector();
+        $this->assertTrue($connector->canCreate());
+    }
+
+    public function testIfCanUpdate()
+    {
+        $connector = new ClientSettingsConnector();
+        $this->assertFalse($connector->canUpdate());
+    }
+
+    public function testIfUpdateTransformsToPost()
+    {
+
+        $connector = new ClientSettingsConnector();
+        $settings = new ClientSettings(['id' => 'test']);
+        $settings->setBrandEnabled(true);
+        $connector->setResource($settings);
+
+        $this->assertSame([ClientSettings::BRAND_ENABLED => true], $connector->getDataForPost());
+    }
 }

--- a/tests/Object/Client/ClientSettingsTest.php
+++ b/tests/Object/Client/ClientSettingsTest.php
@@ -41,7 +41,8 @@ class ClientSettingsTest extends BaseApiResourceTest
 
     public function testValidCreate()
     {
-        $this->assertFalse($this->getConnectorToTest()->canCreate());
+
+        $this->assertTrue($this->getConnectorToTest()->canCreate());
     }
 
     public function testValidUpdate()
@@ -59,6 +60,7 @@ class ClientSettingsTest extends BaseApiResourceTest
 
         $this->assertEquals([ClientSettings::BRAND_ENABLED => true], $connector->getDataForUpdate());
         $this->assertInstanceOf(Response::class, $response);
+        $this->assertFalse($this->getConnectorToTest()->canUpdate());
     }
 
     public function testValidDelete()


### PR DESCRIPTION
http://apidocs.klipfolio.com/docs/client-settings suddenly expects a POST instead of a PUT for an already existing resource.